### PR TITLE
Retry command is evaluated

### DIFF
--- a/helpers/lib
+++ b/helpers/lib
@@ -46,7 +46,7 @@ function retry {
     fi
 
     local count=0
-    until "$@"; do
+    until eval "$@"; do
         # Command failed, otherwise until would have skipped the loop
 
         # Store return code so it can be reported to the user

--- a/init
+++ b/init
@@ -24,6 +24,9 @@ for lib in helpers logging filehandling git k8s test-utils; do
     . "${BASH_LIB_DIR_RELATIVE}/${lib}/lib"
 done
 
+# Export functions to subshells
+eval "$(declare -F | sed -e 's/-f /-fx /')"
+
 # Export the absolute path
 # shellcheck disable=SC2086
 BASH_LIB_DIR="$(abs_path ${BASH_LIB_DIR_RELATIVE})"

--- a/tests-for-this-repo/helpers.bats
+++ b/tests-for-this-repo/helpers.bats
@@ -111,4 +111,8 @@ teardown(){
     assert [ ! -e "${temp_dir}/appendfile" ]
 }
 
-
+@test "retry succeeds with compound statements" {
+    run retry 3 "true && date >> ${afile}"
+    assert_success
+    assert_equal $(wc -l <${afile}) 1
+}


### PR DESCRIPTION
Previously the command was directly executed, but that caused problems
passing in compound statements.

Related: conjurinc/ops#423