### PR TITLE
Fix minor typo

### DIFF
--- a/init
+++ b/init
@@ -3,7 +3,7 @@
 ## Initialisation Functions for the
 ## Conjurinc Bash Library
 
-# Shell Otions
+# Shell Options
 set -euo pipefail
 
 # This script should be sourced before any of


### PR DESCRIPTION
I just noticed the minor typo "Otions" -> "Options" and fixed it.