### PR TITLE
Use logging functions in helpers lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ files within it's directory.
           <li><b>bl_remote_sha_for_ref</b>: Returns the SHA for a given ref from a named remote.</li>
           <li><b>bl_remote_tag_for_sha</b>: Returns the tag corresponding to a SHA from a named remote - if there is one.</li>
           <li><b>bl_tracked_files_excluding_subtrees</b>: List files tracked by git, but excluding any files that are in paths listed in <code>.gittrees</code>.</li>
+          <li><b>bl_gittrees_present</b>: Succeeds if .gittrees is present in the root of the repo, otherwise fails.</li>
           <li><b>bl_cat_gittrees</b>: Returns the contents of .gittrees from the top level of the repo, excluding any comments. Fails if .gittrees is not present.</li>
         </ol>
       </td>

--- a/git/lib
+++ b/git/lib
@@ -64,15 +64,25 @@ function bl_remote_tag_for_sha(){
 
 ## Minimal git subtree functionality required for tests to pass
 # full subtree functionality is not ready for merge.
+function bl_gittrees_present(){
+    local -r git_trees="$(bl_repo_root)/.gittrees"
+    [[ -e "${git_trees}" ]]
+}
+
 function bl_cat_gittrees(){
     local -r git_trees="$(bl_repo_root)/.gittrees"
     local -r subtrees_file_format=".gittrees should contain one subtree per line,\
 space seperated with three fields: subtree_path renmote_url remote_name"
-    [[ -e "${git_trees}" ]] || bl_die ".gittrees file ${git_trees} not found. ${subtrees_file_format}"
-    grep -E -v '^\s*$|^\s*#' "$(bl_repo_root)/.gittrees"
+    bl_gittrees_present || bl_die ".gittrees file ${git_trees} not found. ${subtrees_file_format}"
+    grep -E -v '^\s*$|^\s*#' "$(bl_repo_root)/.gittrees" || true
 }
 
 function bl_tracked_files_excluding_subtrees(){
-    subtrees="$(bl_cat_gittrees | awk '{print $1}' | paste -sd '|' -)"
-    bl_all_files_in_repo | grep -E -v "${subtrees}"
+    if bl_gittrees_present; then
+        subtrees="$(bl_cat_gittrees | awk '{print $1}' | paste -sd '|' -)"
+        bl_all_files_in_repo | grep -E -v "${subtrees}"
+    else
+        bl_log debug ".gittrees not found subtress not excluded" stderr
+        bl_all_files_in_repo
+    fi
 }

--- a/helpers/lib
+++ b/helpers/lib
@@ -3,14 +3,14 @@
 : "${BASH_LIB_DIR:?BASH_LIB_DIR must be set. Please source bash-lib/init before other scripts from bash-lib.}"
 
 function bl_die(){
-    echo "${@}"
+    bl_fatal "${@}"
     exit 1
 }
 
 #safe pushd
 function bl_spushd(){
     if ! pushd "${1}" >/dev/null; then
-        die "pushd ${1} failed :("
+        bl_die "pushd ${1} failed :("
     fi
 }
 
@@ -38,16 +38,14 @@ function bl_retry {
     local -r MAX_BACKOFF=30
 
     if [[ ${#} -lt 2 ]]; then
-        echo "retry usage: retry <retries> <command>"
-        exit 1
+        bl_die "retry usage: retry <retries> <command>"
     fi
 
     local retries=$1
     shift
 
     if ! bl_is_num "${retries}"; then
-        echo "Invalid number of retries: ${retries} for command '${*}'".
-        exit 1
+        bl_die "Invalid number of retries: ${retries} for command '${*}'".
     fi
 
     local count=0
@@ -67,11 +65,11 @@ function bl_retry {
             # Add a random amount to the delay to prevent competing processes
             # from re-colliding.
             wait=$(( backoff + (RANDOM % count) ))
-            echo "'${*}' Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            bl_info "'${*}' Retry $count/$retries exited $exit, retrying in $wait seconds..."
             sleep $wait
         else
             # Out of retries :(
-            echo "Retry $count/$retries exited $exit, no more retries left."
+            bl_error "Retry $count/$retries exited $exit, no more retries left."
             return $exit
         fi
     done
@@ -81,21 +79,18 @@ function bl_retry {
 # retry function that waits a constant number of seconds between attempts.
 function bl_retry_constant {
     if [[ ${#} -lt 3 ]]; then
-        echo "retry usage: retry <retries> <interval (seconds)> <command>"
-        exit 1
+        bl_die "retry usage: retry <retries> <interval (seconds)> <command>"
     fi
 
     local retries=$1; shift
     local interval=$1; shift
 
     if ! bl_is_num "${retries}"; then
-        echo "Invalid number of retries: ${retries} for command '${*}'".
-        exit 1
+        bl_die "Invalid number of retries: ${retries} for command '${*}'"
     fi
 
     if ! bl_is_num "${interval}"; then
-        echo "Invalid interval in seconds: ${retries} for command '${*}'".
-        exit 1
+        bl_die "Invalid interval in seconds: ${retries} for command '${*}'".
     fi
 
     local count=0
@@ -106,11 +101,11 @@ function bl_retry_constant {
         exit=$?
         count=$((count + 1))
         if [ "${count}" -lt "${retries}" ]; then
-            echo "'${*}' Retry $count/$retries exited $exit, retrying in $interval seconds..."
+            bl_info "'${*}' Retry $count/$retries exited $exit, retrying in $interval seconds..."
             sleep "${interval}"
         else
             # Out of retries :(
-            echo "Retry $count/$retries exited $exit, no more retries left."
+            bl_error "Retry $count/$retries exited $exit, no more retries left."
             return $exit
         fi
     done

--- a/logging/lib
+++ b/logging/lib
@@ -30,11 +30,21 @@ function bl_log {
   runtime_log_level="${BASH_LIB_LOG_LEVEL}"
   write_log_level="${1}"
   msg="${2}"
+  out="${3:-stdout}"
 
   bl_check_log_level "${runtime_log_level}"
   bl_check_log_level "${write_log_level}"
 
-  if (( BASH_LIB_LOG_LEVELS[write_log_level] >= BASH_LIB_LOG_LEVELS[runtime_log_level] )); then
+  runtime_level_num="${BASH_LIB_LOG_LEVELS[${runtime_log_level}]}"
+  write_level_num="${BASH_LIB_LOG_LEVELS[${write_log_level}]}"
+
+  if (( write_level_num < runtime_level_num )); then
+    return
+  fi
+
+  if [[ "${out}" == "stderr" ]]; then
+    echo -e "\e[${BASH_LIB_LOG_COLOURS[${write_log_level}]}m${msg}\e[0m" 1>&2
+  else
     echo -e "\e[${BASH_LIB_LOG_COLOURS[${write_log_level}]}m${msg}\e[0m"
   fi
 }

--- a/tests-for-this-repo/git.bats
+++ b/tests-for-this-repo/git.bats
@@ -100,6 +100,19 @@ teardown(){
     assert_success
 }
 
+@test "bl_gittrees_present succeeds when .gittrees file is present" {
+    touch .gittrees
+    run bl_gittrees_present
+    assert_success
+    assert_output ""
+}
+
+@test "bl_gittrees_present fails when .gittrees file is not present" {
+    run bl_gittrees_present
+    assert_failure
+    assert_output ""
+}
+
 @test "bl_cat_gittrees dies when gittrees doesn't exist" {
     run bl_cat_gittrees
     assert_failure

--- a/tests-for-this-repo/helpers.bats
+++ b/tests-for-this-repo/helpers.bats
@@ -17,7 +17,7 @@ teardown(){
 
 @test "bl_die exits and prints message" {
     run bash -c ". ${BASH_LIB_DIR}/init; bl_die msg"
-    assert_output msg
+    assert_output --partial msg
     assert_failure
 }
 

--- a/tests-for-this-repo/logging.bats
+++ b/tests-for-this-repo/logging.bats
@@ -30,6 +30,12 @@ teardown() {
     assert_output --partial test
 }
 
+@test "bl_log outputs mesage when stderr is selected. Note: bats combines stdout and stderr" {
+    run bl_log info test stderr
+    assert_success
+    assert_output --partial "test"
+}
+
 @test "bl_debug doesn't output anything using the default info level" {
     run bl_debug foo
     assert_success


### PR DESCRIPTION
* Start to use the logging functions to improve logging elsewhere in bash-lib.
* Add a output param to `bl_log` so that output can optionally be sent to stderr.
* Fixed a test that failed when running locally because of .gittrees not being created. 