### PR TITLE
Update CODEOWNERS to point to infra team, remove extraneous GH orgs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
-* @cyberark/community-and-integrations-team @conjurinc/community-and-integrations-team @conjurdemos/community-and-integrations-team
+* @cyberark/conjur-infra-team
 
 # Changes to .trivyignore require Security Architect approval
-.trivyignore @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects
+.trivyignore @cyberark/security-architects
 
 # Changes to .codeclimate.yml require Quality Architect approval
-.codeclimate.yml @cyberark/quality-architects @conjurinc/quality-architects @conjurdemos/quality-architects
+.codeclimate.yml @cyberark/quality-architects
 
 # Changes to SECURITY.md require Security Architect approval
-SECURITY.md @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects
+SECURITY.md @cyberark/security-architects


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
- Updates the CODEOWNERS file to not require C&I team review and removes the extra GitHub orgs since I was in there anyhow. 

### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation