### PR TITLE
Return single issue number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.4] - 2020-09-25
+### Changed
+- bl_hub_issue_number_for_title now returns the first matching issue number only, instead of all matching issue numbers separated by newlines.
+
 ## [2.0.3] - 2020-03-13
 ### Added
 - bl_validate_changelog: Validate a changelog against keepachangelog.com format.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ files within it's directory.
           <li><b>bl_hub_creds_available</b>: True if hub creds are available (file or env vars)</li>
           <li><b>bl_hub_check</b>: Preflight check for hub, true if git installed, in git repo, hub installed and hub creds are available</li>
           <li><b>bl_hub_download_latest</b>: Download latest hub binary from github and install to ~/bin or specified path</li>
-          <li><b>bl_hub_issue_number_for_title</b>: Find the issue number for an issue from its title, searches open issues in the current repo. (current repo = workding directory, repo is found by origin remote)</li>
+          <li><b>bl_hub_issue_number_for_title</b>: Find the issue number for an issue from its title, searches open issues in the current repo. (current repo = workding directory, repo is found by origin remote). If multiple issues match the supplied title string, only the first is returned.</li>
           <li><b>bl_hub_add_issue_comment</b>: Add a comment to an issue</li>
           <li><b>bl_hub_comment_or_create_issue</b>: Create issue if an issue matching the title doesn't exist. If a match is found, add a comment to it</li>
         </ol>

--- a/github/lib
+++ b/github/lib
@@ -61,7 +61,7 @@ function bl_hub_issue_number_for_title(){
     bl_hub_check
     hub issue \
         |grep "${title}" \
-        |awk -F'[ #]+' '{print $2}'
+        |awk -F'[ #]+' '{print $2; exit}'
 }
 
 function bl_hub_add_issue_comment(){

--- a/tests-for-this-repo/github.bats
+++ b/tests-for-this-repo/github.bats
@@ -120,6 +120,24 @@ EOF
     assert_output "7"
 }
 
+@test "bl_hub_issue_number_for_title returns a single issue number" {
+    bl_hub_check(){ :; }
+    hub(){
+        [[ "${1}" == "issue" ]] || bl_die "issue subcommand not specified"
+        cat <<EOF
+     #19  Add code coverage to bash-lib   kind/quality
+     #11  Generated Documentation
+     #12  Duplicate
+     #13  Duplicate
+      #7  Clean up
+EOF
+    }
+
+    run bl_hub_issue_number_for_title "Duplicate"
+    assert_success
+    assert_output "12"
+}
+
 @test "bl_hub_add_issue_comment uses the correct URL" {
     bl_hub_check(){ :; }
     hub(){


### PR DESCRIPTION
Previously bl_hub_issue_number_for_title returned all the issue
numbers matching a title. That caused bl_hub_comment_or_create_issue
to fail when trying to add a comment when multiple issues matched
the title.

### What does this PR do?
This PR ensures that bl_issue_number_for_title only returns a single issue number.

### What ticket does this PR close?
Connected to cyberark/bash-lib#42

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation