### PR TITLE
Exclude submodules from bl_all_files_in_repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5] - 2021-02-16
+### Changed
+- bl_all_files_in_repo now excludes submodules
+
 ## [2.0.4] - 2020-09-25
 ### Changed
 - bl_hub_issue_number_for_title now returns the first matching issue number only, instead of all matching issue numbers separated by newlines.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ files within it's directory.
           <li><b>bl_in_git_repo</b>: True if current directory is a git working directory</li>
           <li><b>bl_github_owner_repo</b>: returns $owner/$repo extracted from the url of the origin remote</li>
           <li><b>bl_repo_root</b>: Find the root of the current git repo.</li>
-          <li><b>bl_all_files_in_repo</b>: List files tracked by git.</li>
+          <li><b>bl_all_files_in_repo</b>: List files tracked by git, excludes submodules.</li>
           <li><b>bl_remote_latest_tag</b>: Returns the symbolic name of the latest tag from a remote.</li>
           <li><b>bl_remote_latest_tagged_commit</b>: Returns the SHA of the most recently tagged commit in a remote repo (<code>tag^{}</code>).</li>
           <li><b>bl_remote_sha_for_ref</b>: Returns the SHA for a given ref from a named remote.</li>

--- a/git/lib
+++ b/git/lib
@@ -28,10 +28,13 @@ function bl_repo_root(){
     git rev-parse --show-toplevel
 }
 
-# List files tracked by git
+# List files tracked by git excluding submodules
 function bl_all_files_in_repo(){
     bl_in_git_repo
-    git ls-tree -r HEAD --name-only
+    git ls-files -s | grep -v ^16 | cut -f2-
+    #             ^- show status code ^16 = submodule
+    #                 ^- exclude submodules
+    #                               ^- return only file paths (not status code)
 }
 
 # Find the latest tag available at a repo url

--- a/tests-for-this-repo/git.bats
+++ b/tests-for-this-repo/git.bats
@@ -17,7 +17,10 @@ setup(){
     SKIP_GITLEAKS=YES git commit --allow-empty -m "initial"
     echo "some content" > a_file
     git add a_file
-    git commit -a -m "some operations fail on empty repos"
+    # Add a submodule as that trips up some operations
+    git submodule add https://github.com/cyberark/conjur conjur
+    git submodule update --init
+    SKIP_GITLEAKS=YES git commit -a -m "some operations fail on empty repos"
 }
 
 teardown(){
@@ -112,7 +115,8 @@ teardown(){
     # untracked file shouldn't be listed in output
     date > b
     run bl_all_files_in_repo
-    assert_output "a_file"
+    assert_output ".gitmodules
+a_file"
     assert_success
 }
 


### PR DESCRIPTION
### What does this PR do?
Submodules directories were included but not their files. This caused scripts that expected the file list to only contain files to fail.

This commit excludes submodules so only the files in the repo are listed.

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes updates existing tests to cover submodules.
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation