### PR TITLE
Fix github library name written as git in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ files within it's directory.
       </td>
     </tr>
     <tr>
-      <td><a href="github/lib">git</a></td>
+      <td><a href="github/lib">github</a></td>
       <td>Github Related Functions</td>
       <td>
         <ol>


### PR DESCRIPTION
### What does this PR do?
The readme previously listed the git library twice, when one of them is actually github.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation