### PR TITLE
Pass SHELLCHECK_OPTS to Shell check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.6] - 2021-08-23
+### Changed
+- bl_shellcheck_script now passes SHELLCHECK_OPTS through to the container that runs shellcheck
+
 ## [2.0.5] - 2021-02-16
 ### Changed
 - bl_all_files_in_repo now excludes submodules

--- a/test-utils/lib
+++ b/test-utils/lib
@@ -24,7 +24,11 @@ function bl_shellcheck_script(){
 
     if bash -n "${script}"; then
         # shellcheck disable=SC2086
-        docker run --rm -v "${PWD}:/mnt" ${SHELLCHECK_IMAGE}:${SHELLCHECK_TAG} ${ignores} ${script}
+        docker run \
+            --rm \
+            -v "${PWD}:/mnt" \
+            -e SHELLCHECK_OPTS \
+            ${SHELLCHECK_IMAGE}:${SHELLCHECK_TAG} ${ignores} ${script}
     else
         return 1
     fi


### PR DESCRIPTION
### What does this PR do?
This allows users of bl_shellcheck_script to specifiy their own
configuration options (eg ignores) but still use bl_shellcheck_script.

### What ticket does this PR close?
Related: conjurinc/ops#753

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation