### PR TITLE
Update GKE CI Variables

### DIFF
--- a/secrets.yml
+++ b/secrets.yml
@@ -1,4 +1,4 @@
-KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.9.7/bin/linux/amd64/kubectl
+KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.22.2/bin/linux/amd64/kubectl
 
 GCLOUD_CLUSTER_NAME: !var ci/gke/rapid/cluster-name
 GCLOUD_ZONE: !var ci/gke/zone

--- a/secrets.yml
+++ b/secrets.yml
@@ -1,9 +1,9 @@
 KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.9.7/bin/linux/amd64/kubectl
 
-GCLOUD_CLUSTER_NAME: !var ci/google-container-engine-testbed/gcloud-cluster-name
-GCLOUD_ZONE: !var ci/google-container-engine-testbed/gcloud-zone
-GCLOUD_PROJECT_NAME: !var ci/google-container-engine-testbed/gcloud-project-name
-GCLOUD_SERVICE_KEY: !var:file ci/google-container-engine-testbed/gcloud-service-key
+GCLOUD_CLUSTER_NAME: !var ci/gke/rapid/cluster-name
+GCLOUD_ZONE: !var ci/gke/zone
+GCLOUD_PROJECT_NAME: !var ci/gke/project-name
+GCLOUD_SERVICE_KEY: !var:file ci/gke/service-key
 
 DOCKER_REGISTRY_URL: us.gcr.io
-DOCKER_REGISTRY_PATH: us.gcr.io/conjur-gke-dev
+DOCKER_REGISTRY_PATH: us.gcr.io/refreshing-mark-284016

--- a/tests-for-this-repo/k8s.bats
+++ b/tests-for-this-repo/k8s.bats
@@ -11,7 +11,7 @@
 @test "Kubernetes Cluster Is Available" {
         : ${KUBECTL_CLI_URL:?Required Var, did you run tests via summon?}
         run bl_run_docker_gke_command "kubectl cluster-info"
-        assert_output --regexp "Kubernetes master.* is running at .*https://"
+        assert_output --regexp "Kubernetes.* is running at .*https://"
         assert_success
 }
 


### PR DESCRIPTION
### What does this PR do?
Variables are pulled from conjur to gain access to a GKE cluster
for testing GKE related functions. New GKE clusters are now
available so this commit updates secrets.yml to use the new
clusters before the older clusters are terminated.

### What ticket does this PR close?
Related: conjurinc/ops#811

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation