### PR TITLE
Fix error when not in git repo

### DIFF
--- a/init
+++ b/init
@@ -38,9 +38,9 @@ eval "$(declare -F | sed -e 's/-f /-fx /' | grep 'x bl_')"
 BASH_LIB_DIR="$(bl_abs_path ${BASH_LIB_DIR_RELATIVE})"
 export BASH_LIB_DIR
 
-# Update Submodules
+# Update Submodules, but ignore any errors. This way it won't fail if it's not in a git repo.
 bl_spushd "${BASH_LIB_DIR}"
-    git submodule update --init --recursive
+    git submodule update --init --recursive || true
 bl_spopd
 
 export BATS_CMD="${BASH_LIB_DIR}/test-utils/bats/bin/bats"


### PR DESCRIPTION
### Desired Outcome

When using bash-lib outside of a git repository, the `init` script is failing when it tries to update any git submodules (which is intended to update bash-lib itself when being used as a submodule).

### Implemented Changes


- `init` script ignores any errors generated by the `git submodule update` command.

### Connected Issue/Story

N/A

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
